### PR TITLE
[SS-103] (임시방편) fix: google login 시 unmatched route 나오고 넘어가지 않는 문제 임시방편으로 수정

### DIFF
--- a/app/index.jsx
+++ b/app/index.jsx
@@ -11,7 +11,7 @@ import { useCallback, useEffect } from 'react';
 import { Image, StyleSheet, View } from 'react-native';
 import { AntDesignIconsPack } from '../antdesign-icons';
 import { IoniconsPack } from '../ionicons-icons';
-import { Link } from 'expo-router';
+import { Link, router } from 'expo-router';
 import { GoogleIcon } from './../components/GoogleIcon';
 
 const androidClientId =
@@ -30,6 +30,7 @@ const Login = () => {
         console.log('access token', token);
         // 여기서 토큰을 사용하여 추가 작업을 수행할 수 있습니다.
         // 예: 상태 업데이트, API 호출 등
+        router.replace('(tabs)');
       } else {
         console.log('Access token is undefined');
       }


### PR DESCRIPTION
google login 성공 시 넘어가는 와중에 expo-router에 의해 unmatched route 문구가 뜨는 오류가 있었다. 
완전히 해결하지는 못했고, router의 replace 메소드를 사용해서 unmatched route 문구가 잠깐 보이고 tabs 페이지로 라우팅시키는 것까지만 임시로 구현해두었다. 

임시로 구현해둔 이유는 다른 게 더 급하기 떄문이다... 우선순위 높은 이슈를 우선으로 하되 틈틈이 해결해 보되, 정 안 해결되면 복다훈 멘토님 멘토링이 있는 7월 13일까지는 늦어도 최종적으로 해결할 예정이다!