### PR TITLE
[SZ-48] 주간 캘린더 화면 개발

### DIFF
--- a/app/(tabs)/index.jsx
+++ b/app/(tabs)/index.jsx
@@ -1,11 +1,16 @@
 import { View, StyleSheet } from 'react-native';
-import React from 'react';
+import React, { useState } from 'react';
 import WeeklyCalendar from '@/components/WeeklyCalendar';
+import moment from 'moment';
 
 const TodayView = () => {
+  const [selectedDate, setSelectedDate] = useState(moment());
   return (
     <View style={styles.container}>
-      <WeeklyCalendar />
+      <WeeklyCalendar
+        selectedDate={selectedDate}
+        onSelectedDate={setSelectedDate}
+      />
     </View>
   );
 };

--- a/app/_layout.jsx
+++ b/app/_layout.jsx
@@ -4,19 +4,21 @@ import * as eva from '@eva-design/eva';
 import { EvaIconsPack } from '@ui-kitten/eva-icons';
 import LoginProvider from '@/contexts/LoginContext';
 import { default as theme } from '@/theme/theme.json'; // 커스텀 테마 파일
-
+import { TodosProvider } from '@/contexts/TodoContext';
 const RootLayout = () => {
   return (
     <>
-      <LoginProvider>
-        <IconRegistry icons={[EvaIconsPack]} />
-        <ApplicationProvider {...eva} theme={{ ...eva.light, ...theme }}>
-          <Stack>
-            <Stack.Screen name="index" options={{ headerShown: false }} />
-            <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-          </Stack>
-        </ApplicationProvider>
-      </LoginProvider>
+      <TodosProvider>
+        <LoginProvider>
+          <IconRegistry icons={[EvaIconsPack]} />
+          <ApplicationProvider {...eva} theme={{ ...eva.light, ...theme }}>
+            <Stack>
+              <Stack.Screen name="index" options={{ headerShown: false }} />
+              <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+            </Stack>
+          </ApplicationProvider>
+        </LoginProvider>
+      </TodosProvider>
     </>
   );
 };

--- a/components/WeeklyCalendar.jsx
+++ b/components/WeeklyCalendar.jsx
@@ -4,9 +4,8 @@ import { Layout, Text, Icon, useTheme } from '@ui-kitten/components';
 import { useTodos } from '@/contexts/TodoContext';
 import moment from 'moment';
 import 'moment/locale/ko';
-const WeeklyCalendar = ({ onSelectDate }) => {
+const WeeklyCalendar = ({ selectedDate, onSelectedDate }) => {
   const [currentDate, setcurrentDate] = useState(moment());
-  const [selectedDate, setSelectedDate] = useState(currentDate);
   const theme = useTheme();
   const todos = useTodos();
   const getWeekDates = date => {
@@ -28,17 +27,14 @@ const WeeklyCalendar = ({ onSelectDate }) => {
   }, [currentDate]);
   useEffect(() => {
     moment().isBetween(weekDates[0], weekDates[6])
-      ? setSelectedDate(currentDate)
-      : setSelectedDate(weekDates[0]);
-  }, [weekDates, setSelectedDate, currentDate]);
+      ? onSelectedDate(currentDate)
+      : onSelectedDate(weekDates[0]);
+  }, [weekDates, onSelectedDate, currentDate]);
 
   const handleDateSelect = date => {
-    setSelectedDate(date);
-    // onSelectDate(date);
+    onSelectedDate(date);
   };
-  console.log(currentDate);
-  console.log(selectedDate);
-  console.log(moment().isBetween(weekDates[0], weekDates[6]));
+
   return (
     <Layout style={{ padding: 16 }}>
       <Layout

--- a/components/WeeklyCalendar.jsx
+++ b/components/WeeklyCalendar.jsx
@@ -1,20 +1,20 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { TouchableOpacity } from 'react-native';
 import { Layout, Text, Icon, useTheme } from '@ui-kitten/components';
 import { useTodos } from '@/contexts/TodoContext';
-import moment from 'moment-timezone';
+import moment from 'moment';
+import 'moment/locale/ko';
 const WeeklyCalendar = ({ onSelectDate }) => {
   const [currentDate, setcurrentDate] = useState(moment());
   const [selectedDate, setSelectedDate] = useState(currentDate);
   const theme = useTheme();
   const todos = useTodos();
-
   const getWeekDates = date => {
-    const start = date.clone().startOf('ISOWeek').startOf('day');
+    const start = date.clone().startOf('ISOWeek');
     const r = Array.from({ length: 7 }, (_, i) => start.clone().add(i, 'days'));
     return r;
   };
-  const weekDates = getWeekDates(currentDate);
+  const [weekDates, setwWeekDates] = useState(getWeekDates(currentDate));
 
   const navigateWeek = direction => {
     setcurrentDate(prevDate =>
@@ -23,12 +23,22 @@ const WeeklyCalendar = ({ onSelectDate }) => {
         : prevDate.clone().subtract(7, 'd'),
     );
   };
+  useEffect(() => {
+    setwWeekDates(getWeekDates(currentDate));
+  }, [currentDate]);
+  useEffect(() => {
+    moment().isBetween(weekDates[0], weekDates[6])
+      ? setSelectedDate(currentDate)
+      : setSelectedDate(weekDates[0]);
+  }, [weekDates, setSelectedDate, currentDate]);
 
   const handleDateSelect = date => {
     setSelectedDate(date);
     // onSelectDate(date);
   };
-
+  console.log(currentDate);
+  console.log(selectedDate);
+  console.log(moment().isBetween(weekDates[0], weekDates[6]));
   return (
     <Layout style={{ padding: 16 }}>
       <Layout
@@ -46,7 +56,7 @@ const WeeklyCalendar = ({ onSelectDate }) => {
             style={{ width: 24, height: 24 }}
           />
         </TouchableOpacity>
-        <Text category="h6">{currentDate.format('yyyy년 MM월')}</Text>
+        <Text category="h6">{selectedDate.format('yyyy년 MM월')}</Text>
         <TouchableOpacity onPress={() => navigateWeek('next')}>
           <Icon
             name="arrow-ios-forward-outline"

--- a/components/WeeklyCalendar.jsx
+++ b/components/WeeklyCalendar.jsx
@@ -1,24 +1,26 @@
 import React, { useState } from 'react';
 import { TouchableOpacity } from 'react-native';
 import { Layout, Text, Icon, useTheme } from '@ui-kitten/components';
-import { addDays, subDays, startOfWeek, format } from 'date-fns';
 import { useTodos } from '@/contexts/TodoContext';
-
+import moment from 'moment-timezone';
 const WeeklyCalendar = ({ onSelectDate }) => {
-  const [currentWeek, setCurrentWeek] = useState(new Date());
-  const [selectedDate, setSelectedDate] = useState(currentWeek);
+  const [currentDate, setcurrentDate] = useState(moment());
+  const [selectedDate, setSelectedDate] = useState(currentDate);
   const theme = useTheme();
   const todos = useTodos();
-  const getWeekDates = date => {
-    const start = startOfWeek(date, { weekStartsOn: 1 });
-    return Array.from({ length: 7 }, (_, i) => addDays(start, i));
-  };
 
-  const weekDates = getWeekDates(currentWeek);
+  const getWeekDates = date => {
+    const start = date.clone().startOf('ISOWeek').startOf('day');
+    const r = Array.from({ length: 7 }, (_, i) => start.clone().add(i, 'days'));
+    return r;
+  };
+  const weekDates = getWeekDates(currentDate);
 
   const navigateWeek = direction => {
-    setCurrentWeek(prevWeek =>
-      direction === 'next' ? addDays(prevWeek, 7) : subDays(prevWeek, 7),
+    setcurrentDate(prevDate =>
+      direction === 'next'
+        ? prevDate.clone().add(7, 'd')
+        : prevDate.clone().subtract(7, 'd'),
     );
   };
 
@@ -44,7 +46,7 @@ const WeeklyCalendar = ({ onSelectDate }) => {
             style={{ width: 24, height: 24 }}
           />
         </TouchableOpacity>
-        <Text category="h6">{format(weekDates[0], 'yyyy년 MM월')}</Text>
+        <Text category="h6">{currentDate.format('yyyy년 MM월')}</Text>
         <TouchableOpacity onPress={() => navigateWeek('next')}>
           <Icon
             name="arrow-ios-forward-outline"
@@ -62,36 +64,30 @@ const WeeklyCalendar = ({ onSelectDate }) => {
               alignItems: 'center',
               padding: 8,
               borderRadius: 8,
-              backgroundColor:
-                format(date, 'yyyy-MM-dd') ===
-                format(selectedDate, 'yyyy-MM-dd')
-                  ? theme['color-primary-500']
-                  : 'transparent',
+              backgroundColor: date.isSame(selectedDate, 'day')
+                ? theme['color-primary-500']
+                : 'transparent',
             }}
           >
             <Text
               category="s1"
               style={{
-                color:
-                  format(date, 'yyyy-MM-dd') ===
-                  format(selectedDate, 'yyyy-MM-dd')
-                    ? 'white'
-                    : theme['text-basic-color'],
+                color: date.isSame(selectedDate, 'day')
+                  ? 'white'
+                  : theme['text-basic-color'],
               }}
             >
-              {format(date, 'E')}
+              {date.format('ddd')}
             </Text>
             <Text
               category="h6"
               style={{
-                color:
-                  format(date, 'yyyy-MM-dd') ===
-                  format(selectedDate, 'yyyy-MM-dd')
-                    ? 'white'
-                    : theme['text-basic-color'],
+                color: date.isSame(selectedDate, 'day')
+                  ? 'white'
+                  : theme['text-basic-color'],
               }}
             >
-              {format(date, 'd')}
+              {date.format('D')}
             </Text>
             <Layout
               style={{
@@ -102,13 +98,7 @@ const WeeklyCalendar = ({ onSelectDate }) => {
               }}
             >
               <Text category="c1" style={{ color: theme['color-basic-800'] }}>
-                {
-                  todos.filter(
-                    t =>
-                      format(t.date, 'yyyy-MM-dd') ===
-                      format(date, 'yyyy-MM-dd'),
-                  ).length
-                }
+                {todos.filter(t => date.isSame(t.date, 'day')).length}
               </Text>
             </Layout>
           </TouchableOpacity>

--- a/components/WeeklyCalendar.jsx
+++ b/components/WeeklyCalendar.jsx
@@ -2,12 +2,13 @@ import React, { useState } from 'react';
 import { TouchableOpacity } from 'react-native';
 import { Layout, Text, Icon, useTheme } from '@ui-kitten/components';
 import { addDays, subDays, startOfWeek, format } from 'date-fns';
+import { useTodos } from '@/contexts/TodoContext';
 
-const WeeklyCalendar = ({ onSelectDate, todos }) => {
+const WeeklyCalendar = ({ onSelectDate }) => {
   const [currentWeek, setCurrentWeek] = useState(new Date());
   const [selectedDate, setSelectedDate] = useState(currentWeek);
   const theme = useTheme();
-
+  const todos = useTodos();
   const getWeekDates = date => {
     const start = startOfWeek(date, { weekStartsOn: 1 });
     return Array.from({ length: 7 }, (_, i) => addDays(start, i));
@@ -101,7 +102,13 @@ const WeeklyCalendar = ({ onSelectDate, todos }) => {
               }}
             >
               <Text category="c1" style={{ color: theme['color-basic-800'] }}>
-                0
+                {
+                  todos.filter(
+                    t =>
+                      format(t.date, 'yyyy-MM-dd') ===
+                      format(date, 'yyyy-MM-dd'),
+                  ).length
+                }
               </Text>
             </Layout>
           </TouchableOpacity>

--- a/contexts/TodoContext.js
+++ b/contexts/TodoContext.js
@@ -1,0 +1,57 @@
+import { createContext, useContext, useReducer } from 'react';
+
+const TodosContext = createContext(null);
+const TodoIdContext = createContext(null);
+const TodosDispatchContext = createContext(null);
+
+export function TodosProvider({ children }) {
+  const [todos, dispatch] = useReducer(todosReducer, initialTodos);
+
+  return (
+    <TodosContext.Provider value={todos}>
+      <TodosDispatchContext.Provider value={dispatch}>
+        <TodoIdContext.Provider value={todos.length}>
+          {children}
+        </TodoIdContext.Provider>
+      </TodosDispatchContext.Provider>
+    </TodosContext.Provider>
+  );
+}
+
+export function useTodos() {
+  return useContext(TodosContext);
+}
+
+export function useTodosDispatch() {
+  return useContext(TodosDispatchContext);
+}
+
+export function useTodoId() {
+  return useContext(TodoIdContext);
+}
+
+function todosReducer(tasks, action) {
+  switch (action.type) {
+    case 'added': {
+      return [
+        ...tasks,
+        {
+          id: action.id,
+          text: action.text,
+          done: false,
+          date: action.date,
+        },
+      ];
+    }
+    case 'deleted': {
+      return tasks.filter(t => t.id !== action.id);
+    }
+    default: {
+      throw Error('Unknown action: ' + action.type);
+    }
+  }
+}
+
+const initialTodos = [
+  { id: 0, text: 'Buy a milk', done: false, date: '2024-07-16' },
+];

--- a/contexts/TodoContext.js
+++ b/contexts/TodoContext.js
@@ -1,17 +1,21 @@
-import { createContext, useContext, useReducer } from 'react';
-
+import { createContext, useContext, useReducer, useState } from 'react';
+import moment from 'moment';
+moment.locale('ko)');
 const TodosContext = createContext(null);
 const TodoIdContext = createContext(null);
 const TodosDispatchContext = createContext(null);
+export const TimeContext = createContext(null);
 
 export function TodosProvider({ children }) {
   const [todos, dispatch] = useReducer(todosReducer, initialTodos);
-
+  const [time, setTime] = useState(moment());
   return (
     <TodosContext.Provider value={todos}>
       <TodosDispatchContext.Provider value={dispatch}>
         <TodoIdContext.Provider value={todos.length}>
-          {children}
+          <TimeContext.Provider value={(time, setTime)}>
+            {children}
+          </TimeContext.Provider>
         </TodoIdContext.Provider>
       </TodosDispatchContext.Provider>
     </TodosContext.Provider>

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,8 @@
         "expo-router": "~3.5.17",
         "expo-status-bar": "~1.12.1",
         "expo-web-browser": "~13.0.3",
+        "moment": "^2.30.1",
+        "moment-timezone": "^0.5.45",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-native": "0.74.2",
@@ -13403,6 +13405,25 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.45",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.45.tgz",
+      "integrity": "sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/mrmime": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "expo-router": "~3.5.17",
     "expo-status-bar": "~1.12.1",
     "expo-web-browser": "~13.0.3",
+    "moment": "^2.30.1",
+    "moment-timezone": "^0.5.45",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.74.2",


### PR DESCRIPTION
# What is this PR? 🔍

- 메인 화면에서 주간 캘린더 컴포넌트에 해당하는 부분입니다.
- Jira Ticket: [SZ-48](https://swm-safezone.atlassian.net/browse/SZ-48?atlOrigin=eyJpIjoiYjYxMWIxM2MxOGEyNDEwN2JjZmRmZGVjODQ5OWMxODIiLCJwIjoiaiJ9)

# Changes 📝

- WeeklyCalendar 컴포넌트를 추가했습니다.
- WeeklyCalendar의 부모 컴포넌트인 TodayView에서 selectedDate를 prop으로 전달해줍니다.
- 이를 통해 선택된 날짜를 기준으로 오늘의 할 일 리스트를 출력할 수 있습니다.

앞으로 반영해야 할 것
- 주간 캘린더에서 각 날짜별로 생성된 할 일 갯수를 카운트하는 함수를 [SZ-16](https://swm-safezone.atlassian.net/browse/SZ-16?atlOrigin=eyJpIjoiNDNhYmMwYmRlYjgzNGE4MTk1ZDZmYmQ2MDY5MWFkNmQiLCJwIjoiaiJ9)에서 적용된 zudtand에 맞게 수정해야 함.
- 임시로 만들어두었던 useReducer 삭제해야함.

# Screenshot 📸

| 기능 | 스크린샷 |
|------|---------|
| GIF  | ![Jul-18-2024 16-01-15](https://github.com/user-attachments/assets/a3898fcc-3488-4f60-9bb6-a2eb1f443113)|

![Screenshot of the budget entry screen](https://your-image-url-here.com)

# Test Checklist ✅

- [x] 좌우 꺽쇠를 눌렀을 때 이전주/다음주로 이동해야함.
- [x] selectedDate가 각 주의 첫째 날로 따라와야함
- [x] 오늘이 있는 주는  selectedDate가 오늘이 되어야함
- [x] 상단에 표시되는 OOOO년 OO월에서 OO월이 selectedDate에 맞게 변경되어야함.


[SZ-48]: https://swm-safezone.atlassian.net/browse/SZ-48?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SZ-16]: https://swm-safezone.atlassian.net/browse/SZ-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ