### PR TITLE
[SZ-118] 투두 모달 상태관리 및 API 호출

### DIFF
--- a/components/CategoryTodos.jsx
+++ b/components/CategoryTodos.jsx
@@ -8,7 +8,6 @@ import { isTodoIncludedInTodayView } from '@/utils/dateUtils';
 import { Text } from '@ui-kitten/components';
 import { useContext, useEffect } from 'react';
 import DailyTodos from './DailyTodos';
-import TodoModal from './TodoModal';
 const CategoryTodos = () => {
   const { accessToken, userId } = useContext(LoginContext);
   const { isLoading, error, data, isSuccess } = useTodosQuery(
@@ -55,11 +54,6 @@ const CategoryTodos = () => {
   return (
     <>
       <DailyTodos />
-      <TodoModal
-        item={selectedTodo}
-        visible={modalVisible}
-        closeModal={() => closeModal()}
-      />
     </>
   );
 };

--- a/components/DailySubTodo.jsx
+++ b/components/DailySubTodo.jsx
@@ -6,8 +6,6 @@ import { TouchableOpacity } from 'react-native';
 import TodoModal from './TodoModal';
 
 const DailySubTodo = ({ item }) => {
-  console.log('DailySubTodo item: ', item);
-
   const [completed, setCompleted] = useState(item.isCompleted);
   const openModal = useModalStore(state => state.openModal);
   const selectedTodo = useTodoStore(state => state.selectedTodo);
@@ -76,7 +74,7 @@ const DailySubTodo = ({ item }) => {
         key={item.id}
         accessoryLeft={props => checkIcon(props)}
         accessoryRight={props => settingIcon(props)}
-        onPress={() => openModal(item)}
+        onPress={() => setModalVisible(true)}
         style={{ paddingLeft: 40 }}
       />
       <TodoModal

--- a/components/DailyTodo.jsx
+++ b/components/DailyTodo.jsx
@@ -1,6 +1,12 @@
 import { DateContext } from '@/contexts/DateContext';
+import { LoginContext } from '@/contexts/LoginContext';
 import useModalStore from '@/contexts/ModalStore';
 import useTodoStore from '@/contexts/TodoStore';
+import {
+  SUBTODO_QUERY_KEY,
+  useSubTodoAddMutation,
+} from '@/hooks/useSubTodoMutations';
+import { useQueryClient } from '@tanstack/react-query';
 import {
   Icon,
   Input,
@@ -9,15 +15,10 @@ import {
   Text,
   useTheme,
 } from '@ui-kitten/components';
-import { useCallback, useContext, useRef, useState } from 'react';
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { StyleSheet, TouchableOpacity } from 'react-native';
 import DailySubTodo from './DailySubTodo';
 import TodoModal from './TodoModal';
-
-// const todosApi =
-//   'http://ec2-54-180-249-86.ap-northeast-2.compute.amazonaws.com:8000/todos/';
-
-const todosApi = 'http://localhost:8000/todos/todo/';
 
 const DailyTodo = ({ item, drag, isActive }) => {
   const [content, setContent] = useState(item.content);
@@ -25,7 +26,6 @@ const DailyTodo = ({ item, drag, isActive }) => {
   const { selectedDate } = useContext(DateContext);
   const editTodo = useTodoStore(state => state.editTodo);
   const toggleTodo = useTodoStore(state => state.toggleTodo);
-  const addSubTodo = useTodoStore(state => state.addSubTodo);
   const [completed, setCompleted] = useState(item.isCompleted);
   const openModal = useModalStore(state => state.openModal);
   const closeModal = useModalStore(state => state.closeModal);
@@ -33,16 +33,27 @@ const DailyTodo = ({ item, drag, isActive }) => {
   const setIsEditing = useModalStore(state => state.setIsEditing);
   const selectedTodo = useTodoStore(state => state.selectedTodo);
   const [subTodoInput, setSubtodoInput] = useState('');
+  const { accessToken } = useContext(LoginContext);
   const subTodoInputActivated = useModalStore(
     state => state.subTodoInputActivated,
   );
   const setSubTodoInputActivated = useModalStore(
     state => state.setSubTodoInputActivated,
   );
+  const queryClient = useQueryClient();
+  const { mutate: addSubTodo, isSuccess: addSubTodoIsSuccess } =
+    useSubTodoAddMutation();
 
   const subtodoTextInputRef = useRef(null);
 
   const [modalVisible, setModalVisible] = useState(false);
+
+  useEffect(() => {
+    if (addSubTodoIsSuccess) {
+      queryClient.invalidateQueries(SUBTODO_QUERY_KEY);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [addSubTodoIsSuccess]);
 
   const handleCheck = useCallback(() => {
     setCompleted(!completed);
@@ -95,8 +106,15 @@ const DailyTodo = ({ item, drag, isActive }) => {
 
   const handleSubtodoSubmit = () => {
     if (subTodoInput !== '') {
-      const modifiedDate = selectedDate.toISOString().split('T')[0];
-      addSubTodo(subTodoInput, item, modifiedDate, tmpOrder());
+      const modifiedDate = selectedDate.format('YYYY-MM-DD');
+      const subTodoData = {
+        todo: item.id,
+        content: subTodoInput,
+        date: modifiedDate,
+        isCompleted: false,
+        order: tmpOrder(),
+      };
+      addSubTodo({ accessToken: accessToken, todoData: subTodoData });
       setSubtodoInput('');
       setSubTodoInputActivated(false);
     }

--- a/components/DailyTodo.jsx
+++ b/components/DailyTodo.jsx
@@ -20,8 +20,6 @@ import TodoModal from './TodoModal';
 const todosApi = 'http://localhost:8000/todos/todo/';
 
 const DailyTodo = ({ item, drag, isActive }) => {
-  console.log('DailyTodo item: ', item);
-
   const [content, setContent] = useState(item.content);
   const theme = useTheme();
   const { selectedDate } = useContext(DateContext);
@@ -58,7 +56,6 @@ const DailyTodo = ({ item, drag, isActive }) => {
   };
 
   const renderSubTodo = ({ item, index }) => {
-    console.log('renderSubtodo subitem,', item);
     return <DailySubTodo item={item} key={index} />;
   };
 

--- a/components/DailyTodo.jsx
+++ b/components/DailyTodo.jsx
@@ -15,7 +15,7 @@ import {
   Text,
   useTheme,
 } from '@ui-kitten/components';
-import { useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { useCallback, useContext, useEffect, useState } from 'react';
 import { StyleSheet, TouchableOpacity } from 'react-native';
 import DailySubTodo from './DailySubTodo';
 import TodoModal from './TodoModal';
@@ -44,8 +44,6 @@ const DailyTodo = ({ item, drag, isActive }) => {
   const { mutate: addSubTodo, isSuccess: addSubTodoIsSuccess } =
     useSubTodoAddMutation();
 
-  const subtodoTextInputRef = useRef(null);
-
   const [modalVisible, setModalVisible] = useState(false);
 
   useEffect(() => {
@@ -59,12 +57,6 @@ const DailyTodo = ({ item, drag, isActive }) => {
     setCompleted(!completed);
     toggleTodo({ ...item });
   }, [completed, item, toggleTodo]);
-
-  const focusSubtodoTextInput = () => {
-    if (subtodoTextInputRef.current) {
-      subtodoTextInputRef.current.focus();
-    }
-  };
 
   const renderSubTodo = ({ item, index }) => {
     return <DailySubTodo item={item} key={index} />;

--- a/components/WeeklyCalendar.jsx
+++ b/components/WeeklyCalendar.jsx
@@ -1,5 +1,6 @@
 import { DateContext } from '@/contexts/DateContext';
 import useTodoStore from '@/contexts/TodoStore';
+import { convertGmtToKst } from '@/utils/convertTimezone';
 import { isTodoIncludedInTodayView } from '@/utils/dateUtils';
 import { Icon, Layout, Text, useTheme } from '@ui-kitten/components';
 import moment from 'moment';
@@ -14,7 +15,9 @@ const WeeklyCalendar = () => {
   const todos = useTodoStore(state => state.todos);
   const getWeekDates = date => {
     const start = date.clone().startOf('ISOWeek');
-    const r = Array.from({ length: 7 }, (_, i) => start.clone().add(i, 'days'));
+    const r = Array.from({ length: 7 }, (_, i) =>
+      moment(convertGmtToKst(new Date(start.clone().add(i, 'days')))),
+    );
     return r;
   };
   const [weekDates, setwWeekDates] = useState(getWeekDates(currentDate));

--- a/hooks/useSubTodoMutations.js
+++ b/hooks/useSubTodoMutations.js
@@ -1,7 +1,7 @@
 import { Api } from '@/utils/api';
 import { useMutation } from '@tanstack/react-query';
 
-const SUBTODO_QUERY_KEY = '/sub';
+export const SUBTODO_QUERY_KEY = '/sub';
 
 // 생성 (Add Todo)
 const addSubTodoFetcher = async ({ accessToken, todoData }) => {

--- a/hooks/useSubTodoMutations.js
+++ b/hooks/useSubTodoMutations.js
@@ -1,0 +1,55 @@
+import { Api } from '@/utils/api';
+import { useMutation } from '@tanstack/react-query';
+
+const SUBTODO_QUERY_KEY = '/sub';
+
+// 생성 (Add Todo)
+const addSubTodoFetcher = async ({ accessToken, todoData }) => {
+  const data = await Api.addSubTodo(accessToken, todoData);
+  return data;
+};
+
+export const useSubTodoAddMutation = () => {
+  return useMutation({
+    mutationFn: addSubTodoFetcher,
+    onError: error => {
+      console.error('Error adding todo:', error);
+    },
+  });
+};
+
+// 수정 (Update Todo)
+const updateSubTodoFetcher = async ({ accessToken, updatedData }) => {
+  const data = await Api.updateSubTodo({
+    accessToken: accessToken,
+    updatedData: updatedData,
+  });
+  return data;
+};
+
+export const useSubTodoUpdateMutation = () => {
+  return useMutation({
+    mutationFn: updateSubTodoFetcher,
+    onError: error => {
+      console.error('Error editing todo:', error);
+    },
+  });
+};
+
+// 삭제 (Delete Todo)
+const deleteSubTodoFetcher = async ({ accessToken, subTodoId }) => {
+  const data = await Api.deleteSubTodo({
+    accessToken: accessToken,
+    subTodoId: subTodoId,
+  });
+  return data;
+};
+
+export const useSubTodoDeleteMutation = () => {
+  return useMutation({
+    mutationFn: deleteSubTodoFetcher,
+    onError: error => {
+      console.error('Error deleting todo:', error);
+    },
+  });
+};

--- a/hooks/useTodoMutations.js
+++ b/hooks/useTodoMutations.js
@@ -1,10 +1,8 @@
 import { Api } from '@/utils/api';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import TODO_QUERY_KEY from './useTodoQuery';
+import { useMutation } from '@tanstack/react-query';
 
 // 생성 (Add Todo)
 const addTodoFetcher = async ({ accessToken, todoData }) => {
-  console.log('addTodoFetcher todoData', todoData);
   const data = await Api.addTodo(accessToken, todoData);
   return data;
 };
@@ -19,19 +17,17 @@ export const useTodoAddMutation = () => {
 };
 
 // 수정 (Update Todo)
-const updateTodoFetcher = async (accessToken, todoId, updatedData) => {
-  const data = await Api.updateTodo(accessToken, todoId, updatedData);
+const updateTodoFetcher = async ({ accessToken, updatedData }) => {
+  const data = await Api.updateTodo({
+    accessToken: accessToken,
+    updateData: updatedData,
+  });
   return data;
 };
 
-export const useTodoUpdateMutation = onSuccess => {
-  const queryClient = useQueryClient();
+export const useTodoUpdateMutation = () => {
   return useMutation({
     mutationFn: updateTodoFetcher,
-    onSuccess: () => {
-      queryClient.invalidateQueries(TODO_QUERY_KEY);
-      if (onSuccess) onSuccess();
-    },
     onError: error => {
       console.error('Error editing todo:', error);
     },
@@ -39,19 +35,14 @@ export const useTodoUpdateMutation = onSuccess => {
 };
 
 // 삭제 (Delete Todo)
-const deleteTodoFetcher = async (accessToken, todoId) => {
-  const data = await Api.deleteTodo(accessToken, todoId);
+const deleteTodoFetcher = async ({ accessToken, todoId }) => {
+  const data = await Api.deleteTodo({ accessToken, todoId });
   return data;
 };
 
-export const useTodoDeleteMutation = onSuccess => {
-  const queryClient = useQueryClient();
+export const useTodoDeleteMutation = () => {
   return useMutation({
     mutationFn: deleteTodoFetcher,
-    onSuccess: () => {
-      queryClient.invalidateQueries(TODO_QUERY_KEY);
-      if (onSuccess) onSuccess();
-    },
     onError: error => {
       console.error('Error deleting todo:', error);
     },

--- a/utils/api.js
+++ b/utils/api.js
@@ -14,15 +14,13 @@ const metadata = accessToken => {
     };
   }
 
-  console.log('metadata headers', headers);
-  // return headers;
   return { headers };
 };
 
 const handleRequest = async request => {
   try {
     const response = await request();
-    console.log(response);
+    // console.log(response);
     return response.data;
   } catch (err) {
     console.log(err);
@@ -58,7 +56,6 @@ export const Api = {
    * @throws {Error} 요청이 실패할 경우 에러를 던집니다.
    */
   addTodo: (accessToken, todoData) => {
-    console.log('addTodo todoData', todoData);
     return handleRequest(() =>
       axios.post(API_PATH.todos, todoData, metadata(accessToken)),
     );
@@ -165,7 +162,6 @@ export const Api = {
    * }
    */
   addCategory: (accessToken, categoryData) => {
-    console.log('metadata', metadata());
     return handleRequest(
       // () =>
       //   fetch(API_PATH.categories, {
@@ -181,6 +177,53 @@ export const Api = {
       // }),
       () =>
         axios.post(API_PATH.categories, categoryData, metadata(accessToken)),
+    );
+  },
+  /**
+   * 서버에 서브투두를 추가합니다.
+   *
+   * @example
+   * // subTodoData 예시:
+   * {
+   *   category_id: categoryId,
+   * }
+   */
+  addSubTodo: (accessToken, subTodoData) => {
+    return handleRequest(() =>
+      axios.post(API_PATH.subTodos, subTodoData, metadata(accessToken)),
+    );
+  },
+  /**
+   * 서버에 서브투두를 변경합니다.
+   *
+   * @example
+   * // subTodoData 예시:
+   * {
+   *   sub_id: subTodoId,
+   * }
+   */
+  updateSubTodo: ({ accessToken, updatedData }) => {
+    return handleRequest(() =>
+      axios.patch(API_PATH.subTodos, updatedData, metadata(accessToken)),
+    );
+  },
+  /**
+   * 서버에 서브투두를 삭제합니다.
+   *
+   * @example
+   * // subTodoData 예시:
+   * {
+   *   sub_id: subTodoId,
+   * }
+   */
+  deleteSubTodo: ({ accessToken, subTodoId }) => {
+    return handleRequest(() =>
+      axios.request({
+        url: API_PATH.subTodos,
+        method: 'DELETE',
+        headers: metadata(accessToken),
+        data: { subtodoId: subTodoId },
+      }),
     );
   },
 };

--- a/utils/dateUtils.js
+++ b/utils/dateUtils.js
@@ -1,5 +1,4 @@
 export const isTodoIncludedInTodayView = (startDate, endDate, currentDate) => {
-  console.log(startDate, endDate, currentDate);
   if (startDate && endDate) {
     if (currentDate >= startDate && currentDate <= endDate) {
       return true;


### PR DESCRIPTION
## What is this PR?
Jira SZ-118 투두 모달 창에서 일어나는 모든 상태관리와 API 호출에 대한 PR입니다. 

## Changes
- [x] 날짜 바꾸기 및 인박스 버튼 만들기
- [x] 날짜 바꾸기 버튼을 누르면 캘린더에서 날짜를 선택할 수 있도록 하기
- [x] 투두 생성 API react query를 통해서 호출하도록 코드 수정 및 디버깅 
- [x] CategoryContext에서 selectedCategory의 초기값을 API를 통해 받아오기
- [x] 투두 모달창을 띄우기 위해 투두를 생성하는 API를 react query를 통해서 호출하도록 코드 수정
- [x] 날짜를 선택하면 투두 날짜를 변경하는 API를 호출하고, 바뀐 날짜가 현재 날짜가 아닐 경우 현재 화면창에서 해당 투두를 안 보이게 하기 → 다른 이슈(SZ-195) 처리하면서 완료함
- [x] 투두 날짜수정 API react query를 통해서 호출하도록 코드 작성하기
- [x] 투두 날짜수정 API로 투두 변경하면 해당 날짜에서 사라지도록 상태관리
- [x] 투두인지 하위 투두인지에 따라서 ‘하위 투두 생성하기’ 버튼이 뜨거나 안 뜨도록 하기
- [x] 서브투두 날짜수정 API react query를 통해서 호출하도록 코드 작성하기
- [x] 투두 삭제 API react query를 통해서 호출하도록 코드 작성하기
- [x] 서브투두 삭제 API react query를 통해서 호출하도록 코드 작성하기

## Screenshots
대부분은 어제 보신 그대로입니다. 추가된 사항은 다음과 같습니다:
1. 캘린더 모달창을 통해 투두랑 서브투두 날짜 바꾸기 기능 (react query 사용하는걸로 로직바꿈) 입니다. 
2. 모달창을 통해 투두랑 서브투두 삭제하는 기능 (react query 사용하는걸로 로직바꿈) 입니다.
